### PR TITLE
Allow to pass resolved dependency directly to bypass Coursier completely

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ homepage := Some(url("https://github.com/scalacenter/sbt-scalafix"))
 licenses := List(
   "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
 )
-version := "0.9.5"
+version := "0.9.5-ext"
 
 developers := List(
   Developer(

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -31,7 +31,8 @@ class SbtCompletionsSuite extends FunSuite {
     ScalafixInterface
       .fromToolClasspath(
         Seq(exampleDependency),
-        ScalafixCoursier.defaultResolvers
+        ScalafixCoursier.defaultResolvers,
+        Seq.empty
       )()
       .args
   val loadedRules = mainArgs.availableRules.asScala.toList

--- a/src/test/scala/scalafix/internal/sbt/ScalafixAPISuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/ScalafixAPISuite.scala
@@ -28,6 +28,7 @@ class ScalafixAPISuite extends FunSuite {
     val ScalafixInterface(_, args) = ScalafixInterface.fromToolClasspath(
       List("com.geirsson" %% "example-scalafix-rule" % "1.3.0"),
       ScalafixCoursier.defaultResolvers,
+      Seq.empty,
       logger
     )()
     val tmp = Files.createTempFile("scalafix", "Tmp.scala")


### PR DESCRIPTION
Currently, it works sometimes, but often it not work with 403 error. Looks like some random behavior. 
The number of issues with coursier and Artifactory is so big that I give up (some of them marked as resolved, but they not). Seems I can't find the right combination of how to make it work. Let's bypass it completely. 

https://www.jfrog.com/jira/browse/RTFACT-16725
https://www.jfrog.com/jira/browse/RTFACT-13797
https://github.com/coursier/coursier/issues/1179
https://github.com/coursier/coursier/issues/770
https://github.com/sbt/sbt/issues/4700